### PR TITLE
Fix icon style option spelling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
             "name": "Icon style",
             "default_value": "color",
             "options": [
-                {"text": "Colorfull icon", "value": "color"},
+                {"text": "Colorful icon", "value": "color"},
                 {"text": "Black icon", "value": "black"},
                 {"text": "White icon", "value": "white"}
             ]


### PR DESCRIPTION
I started using your ulauncher extension recently and it has been great!

This pull request is to fix a minor misspelling I noticed while configuring the extension. It's a very small detail (and maybe even intentional), but I thought I'd make this pull request anyways just in case it was something that wasn't noticed. :)